### PR TITLE
Error handling and retry improvements

### DIFF
--- a/pdbe_mcp_server/api_tools.py
+++ b/pdbe_mcp_server/api_tools.py
@@ -1,4 +1,5 @@
 import json
+import time
 from typing import Any
 from urllib.parse import urljoin
 
@@ -253,25 +254,34 @@ class OpenAPIToMCPGenerator:
             if param_name in arguments:
                 path_params[param_name] = arguments[param_name]
 
-        try:
-            if tool_info["method"] == "GET":
-                data = HTTPClient.get(full_url)
-            elif tool_info["method"] == "POST":
-                data = HTTPClient.post(full_url)
-            else:
-                # unsupported method, raise an error
-                raise ValueError(f"Unsupported method: {tool_info['method']}")
+        last_error: requests.RequestException | None = None
+        data = None
+        for attempt in range(3):
+            try:
+                if tool_info["method"] == "GET":
+                    data = HTTPClient.get(full_url)
+                elif tool_info["method"] == "POST":
+                    data = HTTPClient.post(full_url)
+                else:
+                    # unsupported method, raise an error
+                    raise ValueError(f"Unsupported method: {tool_info['method']}")
+                last_error = None
+                break
+            except requests.RequestException as e:
+                last_error = e
+                if attempt < 2:
+                    time.sleep(0.5)
 
-            result_text = json.dumps(data, indent=2)
-            return [types.TextContent(type="text", text=result_text)]
-
-        except requests.RequestException as e:
-            error_message = f"API request failed: {e}"
-            if hasattr(e, "response") and e.response is not None:
-                error_message += f"\nStatus Code: {e.response.status_code}"
-                error_message += f"\nResponse: {e.response.text}"
+        if last_error is not None:
+            error_message = f"API request failed: {last_error}"
+            if hasattr(last_error, "response") and last_error.response is not None:
+                error_message += f"\nStatus Code: {last_error.response.status_code}"
+                error_message += f"\nResponse: {last_error.response.text}"
 
             return [types.TextContent(type="text", text=error_message)]
+
+        result_text = json.dumps(data, indent=2)
+        return [types.TextContent(type="text", text=result_text)]
 
 
 def create_mcp_tools_from_openapi(

--- a/pdbe_mcp_server/graph_tools.py
+++ b/pdbe_mcp_server/graph_tools.py
@@ -273,6 +273,6 @@ class GraphTools:
             A formatted string listing example queries.
         """
         return "\n\n".join(
-            f"Question: {query.get('query', '')}\nQuery:\n{query.get('description', '')}"
+            f"Question: {query.get('description', '')}\nQuery:\n{query.get('query', '')}"
             for query in self.graph_schema.get("examples", [])
         )

--- a/pdbe_mcp_server/search_tools.py
+++ b/pdbe_mcp_server/search_tools.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any
 
 import mcp.types as types
@@ -117,7 +118,19 @@ Retrieves the Solr search schema for the PDBe search service. You can use this t
         if filters:
             fields["fl"] = ",".join(filters)
 
-        data = HTTPClient.get(conf.search.search_api, params=fields)
+        last_error: Exception | None = None
+        data = None
+        for attempt in range(3):
+            try:
+                data = HTTPClient.get(conf.search.search_api, params=fields)
+                last_error = None
+                break
+            except Exception as exc:
+                last_error = exc
+                if attempt < 2:
+                    time.sleep(0.5)
+        if last_error is not None:
+            raise last_error
 
         if "response" not in data:
             raise Exception("Invalid response from search service")

--- a/pdbe_mcp_server/search_tools.py
+++ b/pdbe_mcp_server/search_tools.py
@@ -132,7 +132,7 @@ Retrieves the Solr search schema for the PDBe search service. You can use this t
         if last_error is not None:
             raise last_error
 
-        if "response" not in data:
+        if data is None or "response" not in data:
             raise Exception("Invalid response from search service")
         # Extract the relevant information from the response
         response = data["response"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdbe-mcp-server"
-version = "1.0.1"
+version = "1.0.2"
 description = "A Model Context Protocol (MCP) server for accessing PDBe (Protein Data Bank in Europe) structural biology data and services"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_api_tools.py
+++ b/tests/test_api_tools.py
@@ -196,7 +196,7 @@ class TestOpenAPIToMCPGenerator:
         error = requests.RequestException("Server Error")
         error.response = mock_response
 
-        mock_get.side_effect = [mock_openapi_spec, error]
+        mock_get.side_effect = [mock_openapi_spec, error, error, error]
 
         generator = OpenAPIToMCPGenerator("https://example.com/openapi.json")
         generator.list_tools()
@@ -210,6 +210,7 @@ class TestOpenAPIToMCPGenerator:
         assert isinstance(result[0], TextContent)
         assert "API request failed" in result[0].text
         assert "500" in result[0].text
+        assert mock_get.call_count == 4
 
     def test_extract_parameters(self) -> None:
         """Test parameter extraction."""

--- a/tests/test_graph_tools.py
+++ b/tests/test_graph_tools.py
@@ -222,12 +222,12 @@ class TestGraphTools:
             **mock_graph_schema,
             "examples": [
                 {
-                    "query": "Find all structures",
-                    "description": "MATCH (s:Structure) RETURN s",
+                    "description": "Find all structures",
+                    "query": "MATCH (s:Structure) RETURN s",
                 },
                 {
-                    "query": "Find ligands",
-                    "description": "MATCH (l:Ligand) RETURN l",
+                    "description": "Find ligands",
+                    "query": "MATCH (l:Ligand) RETURN l",
                 },
             ],
         }

--- a/uv.lock
+++ b/uv.lock
@@ -635,7 +635,7 @@ wheels = [
 
 [[package]]
 name = "pdbe-mcp-server"
-version = "1.0.0"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This pull request introduces improved error handling and retry logic for API and search queries, along with a minor fix to example query formatting. These changes make the server more robust against transient failures and improve the clarity of example outputs.

**Error handling and retry improvements:**

* Added retry logic with up to 3 attempts and a short delay for API calls in `call_tool`, handling transient `requests.RequestException` errors and improving error reporting in `pdbe_mcp_server/api_tools.py` [[1]](diffhunk://#diff-3b35e111a3ecae07e0bdafee70479f7ea51c8320f9aaa6885c08179e31c7b4e8R2) [[2]](diffhunk://#diff-3b35e111a3ecae07e0bdafee70479f7ea51c8320f9aaa6885c08179e31c7b4e8R257-R259) [[3]](diffhunk://#diff-3b35e111a3ecae07e0bdafee70479f7ea51c8320f9aaa6885c08179e31c7b4e8L264-R285).
* Added similar retry logic for search queries in `run_search_query`, retrying up to 3 times on exceptions and raising the last error if all attempts fail in `pdbe_mcp_server/search_tools.py` [[1]](diffhunk://#diff-0db9c131bc3ef02fa8a9cf5380d5083582ee6528b13e27b295b2d8e22704cd91R1) [[2]](diffhunk://#diff-0db9c131bc3ef02fa8a9cf5380d5083582ee6528b13e27b295b2d8e22704cd91R121-R133).

**Other improvements:**

* Fixed the formatting of example queries to correctly label the 'Question' and 'Query' fields in `format_example_queries` in `pdbe_mcp_server/graph_tools.py`.
* Bumped the package version to `1.0.2` in `pyproject.toml`.