### PR TITLE
Restructure README to de-emphasize Graph Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # PDBe MCP Servers
 
-A set of Model Context Protocol (MCP) servers that provides seamless access to the Protein Data Bank in Europe (PDBe) API, [PDBe Graph Database](https://www.ebi.ac.uk/pdbe/pdbe-kb/graph), and PDBe Search. This server exposes PDBe's comprehensive structural biology data as MCP tools, enabling direct integration with Claude Desktop and other AI-powered applications.
+A set of Model Context Protocol (MCP) servers that provides seamless access to the Protein Data Bank in Europe (PDBe) API and PDBe Search. These servers expose PDBe's comprehensive structural biology data as MCP tools, enabling direct integration with Claude Desktop and other AI-powered applications.
+
+The package also includes an advanced PDBe Graph server for users who run their own local PDBe-KB Neo4j graph database. PDBe does not provide a public running graph database instance for this MCP server to query, so most users should start with the API and Search servers.
 
 **Features:**
 - **PDBe API Server**: Access core structural data through REST API endpoints
-- **PDBe Graph Server**: Query complex relationships and molecular interactions
 - **PDBe Search Server**: Perform advanced Solr-based searches across structural data
+- **PDBe Graph Server**: Inspect the graph schema and, with a local PDBe-KB Neo4j setup, query complex relationships and molecular interactions
 
 ## Prerequisites
 
@@ -16,7 +18,7 @@ A set of Model Context Protocol (MCP) servers that provides seamless access to t
 
 ### Quick Start
 
-**Install directly from PyPI:**
+**Run directly from PyPI:**
 ```bash
 uvx pdbe-mcp-server
 ```
@@ -52,7 +54,7 @@ For development work or customization:
    - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
    - **Linux**: `~/.config/Claude/claude_desktop_config.json`
 
-2. **Add the PDBe MCP server configuration:**
+2. **Add the recommended PDBe MCP server configuration:**
 
    **For PyPI installation (recommended):**
    ```json
@@ -64,14 +66,6 @@ For development work or customization:
            "pdbe-mcp-server",
            "--server-type",
            "pdbe_api_server"
-         ]
-       },
-       "PDBe Graph Server": {
-         "command": "uvx",
-         "args": [
-           "pdbe-mcp-server",
-           "--server-type",
-           "pdbe_graph_server"
          ]
        },
        "PDBe Search Server": {
@@ -101,17 +95,6 @@ For development work or customization:
            "pdbe_api_server"
          ]
        },
-       "PDBe Graph": {
-         "command": "/usr/local/bin/uv",
-         "args": [
-           "run",
-           "--directory",
-           "/path/to/your/PDBe-MCP-Servers",
-           "pdbe-mcp-server",
-           "--server-type",
-           "pdbe_graph_server"
-         ]
-       },
        "PDBe Search": {
          "command": "/usr/local/bin/uv",
          "args": [
@@ -131,6 +114,8 @@ For development work or customization:
   > - For the PyPI installation method, ensure `uvx` is available in your PATH (this comes with uv)
   > - For local development, ensure that `uv` is installed and the `/path/to/your/PDBe-MCP-Servers` matches your actual directory
 
+   Add the graph server only if you have a local PDBe-KB Neo4j graph database configured. See [Advanced Graph Server Configuration](#advanced-graph-server-configuration).
+
 3. **Restart Claude Desktop** to load the new configuration.
 
 ### Using in Claude
@@ -139,60 +124,23 @@ Once configured, you can access PDBe tools directly in your Claude conversations
 
 - **Search for protein structures**: "Find structures for UniProt accession P12345"
 - **Query structure releases**: "Show me all structures released this month grouped by experimental method"
-- **Explore molecular interactions**: "Show me ligand binding sites for this protein"
 - **Advanced search queries**: "Find all X-ray crystal structures with resolution better than 2.0 Å from 2024"
 
-The tools will appear in Claude's "Search and tools" interface, where you can enable or disable them as needed.
+The tools will appear in Claude's tools interface, where you can enable or disable them as needed.
 
 ### Server Types
 
 - **`pdbe_api_server`**: Core PDBe REST API access with essential structural data
-- **`pdbe_graph_server`**: Know more about the PDBe Graph Database and generate Cypher queries for accessing complex relationships and interactions
 - **`pdbe_search_server`**: Advanced Solr-based search capabilities for complex structural queries and data analysis
+- **`pdbe_graph_server`**: Advanced/local server for inspecting the PDBe-KB graph schema and optionally executing read-only Cypher queries against a locally configured Neo4j database
 
-## Search Server Features
+## Tool Reference
 
-The PDBe Search Server provides powerful querying capabilities through the PDBe Solr search interface:
+### API Server Tools
 
-### Available Tools
+The `pdbe_api_server` generates tools from the PDBe API OpenAPI specification. Use this server for core PDBe REST API data, such as entries, assemblies, molecules, ligands, publications, and validation information.
 
-#### `pdbe_graph_nodes`
-Retrieves metadata about all node types (labels) defined in the PDBe graph database schema. Use this to understand the different types of entities and their properties.
-
-**Example usage:**
-```
-"Show me all node types in the PDBe graph database"
-```
-
-#### `pdbe_graph_edges`
-Retrieves metadata about all relationship types (edges) defined in the PDBe graph database schema. Use this to understand how entities are connected.
-
-**Example usage:**
-```
-"Show me all relationship types in the PDBe graph database"
-```
-
-#### `pdbe_graph_example_queries`
-Retrieves example Cypher queries that demonstrate how to interact with the PDBe graph database.
-
-**Example usage:**
-```
-"Give me example Cypher queries for exploring the PDBe graph"
-```
-
-#### `pdbe_run_cypher_query`
-Execute custom read-only Cypher queries against a Neo4j graph database. Only available when Neo4j environment variables are configured.
-
-**Parameters:**
-- `cypher_query` (required): The Cypher query to execute. Only MATCH and OPTIONAL MATCH queries are allowed.
-
-**Example usage:**
-```
-"Execute query: MATCH (s:Structure) WHERE s.PDB_ID = '1abc' RETURN s.TITLE as title"
-"Find ligands: MATCH (s:Structure)-[:HAS_LIGAND]->(l:Ligand) WHERE s.PDB_ID = '1abc' RETURN l.name"
-```
-
-> **Note:** Write operations (MERGE, CREATE, DELETE, REMOVE, SET, LOAD CSV, FOREACH) are blocked for safety.
+### Search Server Tools
 
 #### `get_search_schema`
 Retrieves the complete Solr search schema showing all available fields, data types, and descriptions. Use this to understand what fields you can search and filter on.
@@ -271,14 +219,14 @@ For contributing or development work, first clone the repository and then instal
 ```bash
 git clone https://github.com/PDBeurope/PDBe-MCP-Servers.git
 cd PDBe-MCP-Servers
-uv pip install -e ".[dev]"
+uv sync --all-extras --dev
 ```
 
 **Node.js** (optional) - For using the MCP Inspector development tool
 
 ### Starting the Server Manually
 
-Choose between two server types based on your needs:
+Most users should run the API server, the Search server, or both.
 
 #### PDBe API Server
 Provides access to core PDBe REST API endpoints:
@@ -292,42 +240,6 @@ uvx pdbe-mcp-server --server-type pdbe_api_server --transport sse
 ```bash
 uv run pdbe-mcp-server --server-type pdbe_api_server --transport sse
 ```
-
-#### PDBe Graph Database Server
-Enables complex relationship queries and network analysis:
-
-**Using PyPI installation:**
-```bash
-uvx pdbe-mcp-server --server-type pdbe_graph_server --transport sse
-```
-
-**Using local development:**
-```bash
-uv run pdbe-mcp-server --server-type pdbe_graph_server --transport sse
-```
-
-### Neo4j Cypher Query Support
-
-This server supports executing custom Cypher queries against a Neo4j graph database. The `pdbe_run_cypher_query` tool is only available when the following environment variables are set:
-
-- `NEO4J_URL`: The Neo4j database URL (e.g., `bolt://localhost:7687`)
-- `NEO4J_USERNAME`: The Neo4j username
-- `NEO4J_PASSWORD`: The Neo4j password
-- `NEO4J_DATABASE` (optional): The database name. When set, this is passed to the Neo4j driver for Neo4j 4+. For Neo4j 3.5 compatibility, omit this variable to use the default database.
-
-To use this feature, install the neo4j driver:
-```bash
-pip install neo4j
-```
-
-**Security:** Only read-only queries are allowed (MATCH, OPTIONAL MATCH). Write operations (MERGE, CREATE, DELETE, REMOVE, SET, LOAD CSV, FOREACH) are blocked to prevent accidental data modification.
-
-**Example usage:**
-```
-Execute query: MATCH (s:Structure) WHERE s.PDB_ID = '1abc' RETURN s.PDB_ID as id, s.TITLE as title
-```
-
-The tool response is formatted as JSON by default, but can be converted to TOON format by setting `TOON_ENABLED=true`.
 
 #### PDBe Search Server
 Provides advanced Solr-based search and analytics capabilities:
@@ -344,7 +256,126 @@ uv run pdbe-mcp-server --server-type pdbe_search_server --transport sse
 
 The server will start at `http://localhost:8000/sse` by default.
 
-### Development and Testing
+## Advanced Graph Server Configuration
+
+The `pdbe_graph_server` is intended for users who have downloaded and configured the PDBe-KB graph database in their own environment. PDBe does not provide a public running Neo4j instance for this MCP server to query.
+
+To set up the graph database locally, follow the PDBe-KB graph documentation:
+https://www.ebi.ac.uk/pdbe/pdbe-kb/graph
+
+Once your local Neo4j database is running, set these environment variables before starting the graph server:
+
+- `NEO4J_URL`: The Neo4j database URL (e.g., `bolt://localhost:7687`)
+- `NEO4J_USERNAME`: The Neo4j username
+- `NEO4J_PASSWORD`: The Neo4j password
+- `NEO4J_DATABASE` (optional): The database name. When set, this is passed to the Neo4j driver for Neo4j 4+. For Neo4j 3.5 compatibility, omit this variable to use the default database.
+
+The Neo4j driver is included in this package's dependencies.
+
+### Claude Desktop Graph Configuration
+
+Add this server only when the environment variables above are available to Claude Desktop.
+
+**For PyPI installation:**
+```json
+{
+  "mcpServers": {
+    "PDBe Graph Server": {
+      "command": "uvx",
+      "args": [
+        "pdbe-mcp-server",
+        "--server-type",
+        "pdbe_graph_server"
+      ],
+      "env": {
+        "NEO4J_URL": "bolt://localhost:7687",
+        "NEO4J_USERNAME": "neo4j",
+        "NEO4J_PASSWORD": "your-password"
+      }
+    }
+  }
+}
+```
+
+**For local development installation:**
+```json
+{
+  "mcpServers": {
+    "PDBe Graph": {
+      "command": "/usr/local/bin/uv",
+      "args": [
+        "run",
+        "--directory",
+        "/path/to/your/PDBe-MCP-Servers",
+        "pdbe-mcp-server",
+        "--server-type",
+        "pdbe_graph_server"
+      ],
+      "env": {
+        "NEO4J_URL": "bolt://localhost:7687",
+        "NEO4J_USERNAME": "neo4j",
+        "NEO4J_PASSWORD": "your-password"
+      }
+    }
+  }
+}
+```
+
+### Starting the Graph Server Manually
+
+**Using PyPI installation:**
+```bash
+uvx pdbe-mcp-server --server-type pdbe_graph_server --transport sse
+```
+
+**Using local development:**
+```bash
+uv run pdbe-mcp-server --server-type pdbe_graph_server --transport sse
+```
+
+### Graph Server Tools
+
+#### `pdbe_graph_nodes`
+Retrieves metadata about all node types (labels) defined in the PDBe graph database schema. This uses the public graph schema and does not require local Neo4j credentials.
+
+**Example usage:**
+```
+"Show me all node types in the PDBe graph database"
+```
+
+#### `pdbe_graph_edges`
+Retrieves metadata about all relationship types (edges) defined in the PDBe graph database schema. This uses the public graph schema and does not require local Neo4j credentials.
+
+**Example usage:**
+```
+"Show me all relationship types in the PDBe graph database"
+```
+
+#### `pdbe_graph_example_queries`
+Retrieves example Cypher queries that demonstrate how to interact with the PDBe graph database. This uses the public graph schema and does not require local Neo4j credentials.
+
+**Example usage:**
+```
+"Give me example Cypher queries for exploring the PDBe graph"
+```
+
+#### `pdbe_run_cypher_query`
+Execute custom read-only Cypher queries against your configured Neo4j graph database. This tool is only available when Neo4j environment variables are configured.
+
+**Parameters:**
+- `cypher_query` (required): The Cypher query to execute. Only MATCH and OPTIONAL MATCH queries are allowed.
+
+**Example usage:**
+```
+"Execute query: MATCH (s:Structure) WHERE s.PDB_ID = '1abc' RETURN s.TITLE as title"
+"Find ligands: MATCH (s:Structure)-[:HAS_LIGAND]->(l:Ligand) WHERE s.PDB_ID = '1abc' RETURN l.name"
+```
+
+**Security:** Only read-only queries are allowed (MATCH, OPTIONAL MATCH). Write operations (MERGE, CREATE, DELETE, REMOVE, SET, LOAD CSV, FOREACH) are blocked to prevent accidental data modification.
+
+The tool response is formatted as JSON by default, but can be converted to TOON format by setting `TOON_ENABLED=true`.
+
+## Development and Testing
 
 Explore available tools and test API responses:
 ```bash
@@ -353,16 +384,16 @@ npx @modelcontextprotocol/inspector
 
 The MCP Inspector provides an interactive interface to browse tools, test queries, and validate responses before integrating with your application.
 
-### Server Configuration
+## Server Configuration
 
-#### Transport Options
+### Transport Options
 
 - **stdio**: Default mode - Optimal for direct client integration like Claude Desktop
 - **SSE (Server-Sent Events)**: `--transport sse` - Best for web-based clients and development
 
-#### Experimental TOON Output
+### Experimental TOON Output
 
-You can enable experimental TOON-formatted output for PDBe API tool responses by setting
+You can enable experimental TOON-formatted output for PDBe API tool responses and Neo4j Cypher query results by setting
 the environment variable `TOON_ENABLED=true`.
 See the TOON format specification at https://toonformat.dev/.
 


### PR DESCRIPTION
Remove Graph Server from default Claude Desktop configuration examples, as it requires a local PDBe-KB Neo4j instance. Move all graph setup and tool documentation to a dedicated "Advanced" section. Update the development installation command to use `uv sync`, and reorganize the remaining content into clear Tool Reference and Server Configuration sections.