### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/PDBeurope/PDBe-MCP-Servers/security/code-scanning/2](https://github.com/PDBeurope/PDBe-MCP-Servers/security/code-scanning/2)

Add an explicit workflow-level `permissions` block so all jobs default to least privilege, and keep the existing job-level override for `publish`.

Best fix here: in `.github/workflows/ci.yml`, insert at the root (after `on:` block and before `jobs:`):

- `permissions:`
  - `contents: read`

This preserves current functionality while ensuring `test`/`build` do not inherit broader defaults. The `publish` job can still request `id-token: write` as it already does.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
